### PR TITLE
Add additional ignore files for logs and schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 toolbelt.log
+workers/unity/zip_toolbelt.log
+workers/unity/\\client.log*
+
 spatialos_worker_packages.json
 build/
+
+# when using the new schema system
+.protocache
+
+# when including the schema folder as module
+schema/schema.iml


### PR DESCRIPTION
When you are working with the application it will generate log files in the unity worker folder as well that are best ignored.  In addition the new schema system will add a cache folder called `.protocache` that may also be ignored and when you add your schema folder to IntelliJ as module it will add a schema.iml that can also be left out of your version control system.